### PR TITLE
adds support for the `gpb_header_include` flag to correct imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,18 @@ protoc --plugin=protoc-gen-gleam -I . --gleam_out="output_path=./src:./src" prot
 
 - 'output_path': (Required) specifies the desired output path
 - 'protoc_erl_path': path to gpb's protoc-erl
+- 'gpb_header_include': path to prepend to the header include for gpb. See [Issues](#Issues) for more info
+  - if you need a variable include here, remember that [erlang header resolution](https://www.erlang.org/doc/reference_manual/macros.html) is quite clever and can use environment variables
 
 ```bash
-protoc -I . --gleam_out="output_path=./src,protoc_erl_path=bin/protoc-erl:./src" protos/*.proto
+protoc -I . \
+  --gleam_out="gpb_header_include=$ENV/include/,output_path=./src,protoc_erl_path=bin/protoc-erl:./src" \
+  protos/*.proto
 ```
 
-### Issues
+### Known Issues
 
-You may need to manually update
+#### Includes aren't working?!
 
 ```erlang
 % generated in `gleam_gpb.erl`

--- a/pkg/gleam/gpb.go
+++ b/pkg/gleam/gpb.go
@@ -3,26 +3,31 @@ package gleam
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
+	"strings"
 )
 
 type gpbWrapper struct {
 	pathToBinary string
+	outputPath   string
 }
 
-func newGPBWrapper(pathToBinary string) (*gpbWrapper, error) {
-	if !exists(pathToBinary) {
+func newGPBWrapper(pathToBinary string, outputPath string) (*gpbWrapper, error) {
+	if _, exists := exists(pathToBinary); !exists {
 		return nil, fmt.Errorf("protoc-erl could not be found at %s", pathToBinary)
 	}
 
 	return &gpbWrapper{
 		pathToBinary: pathToBinary,
+		outputPath:   outputPath,
 	}, nil
 }
 
-func (g *gpbWrapper) generate(targets []string, outputPath string) (err error) {
-	args := []string{"-pkgs", "-modname", "gleam_gpb", "-I", ".", "-o", outputPath}
+func (g *gpbWrapper) generate(targets []string) (err error) {
+	args := []string{"-pkgs", "-modname", "gleam_gpb", "-I", ".", "-o", g.outputPath}
 	args = append(args, targets...)
 
 	cmd := exec.Command(g.pathToBinary, args...)
@@ -35,7 +40,38 @@ func (g *gpbWrapper) generate(targets []string, outputPath string) (err error) {
 	return nil
 }
 
-func exists(path string) bool {
-	_, err := os.Open(path)
-	return !errors.Is(err, os.ErrNotExist)
+const headerFileName = "gpb.hrl"
+
+func (g *gpbWrapper) updateImport(correctPath string) (err error) {
+	expectedPath := path.Join(g.outputPath, "gleam_gpb.erl")
+
+	if f, exists := exists(expectedPath); !exists {
+		return fmt.Errorf("updateImport failed: Could not find %s", expectedPath)
+	} else if b, err := ioutil.ReadAll(f); err != nil {
+		return err
+	} else {
+		contents := string(b)
+
+		newHeaderPath := path.Join(correctPath, headerFileName)
+		newContents := strings.Replace(contents, formatReplace(headerFileName), formatReplace(newHeaderPath), 1)
+
+		if err := os.WriteFile(expectedPath, []byte(newContents), 0666); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func formatReplace(path string) string {
+	return fmt.Sprintf("-include(\"%s\").", path)
+}
+
+func exists(path string) (*os.File, bool) {
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) || err != nil {
+		return nil, false
+	}
+
+	return f, true
 }


### PR DESCRIPTION
- cleans up `gpbWrapper` usage in `module.go` some
- adds a new flag to programmatically update the gpb header include in `gleam_gpb.erl`
- updates `README.md` with info on this

